### PR TITLE
Allow specifying IP networks for permitted proxies in place of IP addresses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1097,7 @@ dependencies = [
 name = "warp-real-ip"
 version = "0.2.0"
 dependencies = [
+ "ipnetwork",
  "rfc7239",
  "tokio",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/warp-real-ip"
 [dependencies]
 warp = { version = "0.3" }
 rfc7239 = "0.1"
+ipnetwork = "~0.18"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,12 @@ impl IpNetworks {
     }
 }
 
+impl From<Vec<IpAddr>> for IpNetworks {
+    fn from(addrs: Vec<IpAddr>) -> Self {
+        Self::from_ipaddr_iter(addrs.iter())
+    }
+}
+
 impl From<&Vec<IpAddr>> for IpNetworks {
     fn from(addrs: &Vec<IpAddr>) -> Self {
         Self::from_ipaddr_iter(addrs.iter())
@@ -65,8 +71,9 @@ impl FromIterator<IpNetwork> for IpNetworks {
 ///     .map(|addr: Option<IpAddr>| format!("Hello {}", addr.unwrap()));
 /// ```
 pub fn real_ip(
-    trusted_proxies: IpNetworks,
+    trusted_proxies: impl Into<IpNetworks>,
 ) -> impl Filter<Extract = (Option<IpAddr>,), Error = Infallible> + Clone {
+    let trusted_proxies = trusted_proxies.into();
     remote().and(get_forwarded_for()).map(
         move |addr: Option<SocketAddr>, forwarded_for: Vec<IpAddr>| {
             addr.map(|addr| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,27 +18,28 @@ impl IpNetworks {
     pub fn contains(&self, addr: &IpAddr) -> bool {
         self.networks.iter().any(|&network| network.contains(*addr))
     }
-
-    /// Special constructor that builds IpNetwork from an iterator of IP addresses.
-    pub fn from_ipaddr_iter<'a, T: Iterator<Item = &'a IpAddr>>(addrs: T) -> Self {
-        Self::from_iter(addrs.map(|&addr| -> IpNetwork {
-            match addr {
-                IpAddr::V4(addr) => Ipv4Network::from(addr).into(),
-                IpAddr::V6(addr) => Ipv6Network::from(addr).into(),
-            }
-        }))
-    }
 }
 
 impl From<Vec<IpAddr>> for IpNetworks {
     fn from(addrs: Vec<IpAddr>) -> Self {
-        Self::from_ipaddr_iter(addrs.iter())
+        Self::from_iter(addrs.iter())
     }
 }
 
 impl From<&Vec<IpAddr>> for IpNetworks {
     fn from(addrs: &Vec<IpAddr>) -> Self {
-        Self::from_ipaddr_iter(addrs.iter())
+        Self::from_iter(addrs.iter())
+    }
+}
+
+impl<'a> FromIterator<&'a IpAddr> for IpNetworks {
+    fn from_iter<T: IntoIterator<Item = &'a IpAddr>>(addrs: T) -> Self {
+        Self::from_iter(addrs.into_iter().map(|&addr| -> IpNetwork {
+            match addr {
+                IpAddr::V4(addr) => Ipv4Network::from(addr).into(),
+                IpAddr::V6(addr) => Ipv6Network::from(addr).into(),
+            }
+        }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,19 @@ use std::str::FromStr;
 use warp::filters::addr::remote;
 use warp::Filter;
 
-#[derive(Clone)]
+/// Represents a set of IP networks.
+#[derive(Debug, Clone)]
 pub struct IpNetworks {
     networks: Vec<IpNetwork>,
 }
 
 impl IpNetworks {
+    /// Checks if addr is part of any IP networks included.
     pub fn contains(&self, addr: &IpAddr) -> bool {
         self.networks.iter().any(|&network| network.contains(*addr))
     }
 
+    /// Special constructor that builds IpNetwork from an iterator of IP addresses.
     pub fn from_ipaddr_iter<'a, T: Iterator<Item = &'a IpAddr>>(addrs: T) -> Self {
         Self::from_iter(addrs.map(|&addr| -> IpNetwork {
             match addr {
@@ -24,6 +27,12 @@ impl IpNetworks {
                 IpAddr::V6(addr) => Ipv6Network::from(addr).into(),
             }
         }))
+    }
+}
+
+impl From<&Vec<IpAddr>> for IpNetworks {
+    fn from(addrs: &Vec<IpAddr>) -> Self {
+        Self::from_ipaddr_iter(addrs.iter())
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ use warp_real_ip::real_ip;
 
 fn serve<'a>(trusted: Vec<IpAddr>) -> impl Filter<Extract = (String,)> + 'a {
     warp::any()
-        .and(real_ip((&trusted).into()))
+        .and(real_ip(trusted))
         .map(|addr: Option<IpAddr>| addr.unwrap().to_string())
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
 use std::net::IpAddr;
 use warp::Filter;
-use warp_real_ip::{IpNetworks, real_ip};
+use warp_real_ip::real_ip;
 
 fn serve<'a>(trusted: Vec<IpAddr>) -> impl Filter<Extract = (String,)> + 'a {
     warp::any()
-        .and(real_ip(IpNetworks::from_ipaddr_iter(trusted.iter())))
+        .and(real_ip((&trusted).into()))
         .map(|addr: Option<IpAddr>| addr.unwrap().to_string())
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
 use std::net::IpAddr;
 use warp::Filter;
-use warp_real_ip::real_ip;
+use warp_real_ip::{IpNetworks, real_ip};
 
 fn serve<'a>(trusted: Vec<IpAddr>) -> impl Filter<Extract = (String,)> + 'a {
     warp::any()
-        .and(real_ip(trusted))
+        .and(real_ip(IpNetworks::from_ipaddr_iter(trusted.iter())))
         .map(|addr: Option<IpAddr>| addr.unwrap().to_string())
 }
 


### PR DESCRIPTION
This patch allows one to specify IP network (e.g. `192.168.0.0/16`) for proxies to allow.  I gave it some tries but I couldn't avoid API change.